### PR TITLE
fix: resolve deme state duplication across generations

### DIFF
--- a/deme/expand-deme.metta
+++ b/deme/expand-deme.metta
@@ -165,7 +165,7 @@ $optimDeme
          (if (<= (param maxCandOutput) (OS.length $updatedMetaPop))
              (OS.getTopN (param maxCandOutput) $updatedMetaPop)
              $updatedMetaPop)
-         (runMoses (- $maxGen 1) $maxScore $updatedMetaPop $nExpansion $nDeme $context $optimize)))))
+         (runMoses (- $maxGen 1) $maxScore $updatedMetaPop (+ $nExpansion 1) $nDeme $context $optimize)))))
 
 
 ;; Some helpers specific to final testing


### PR DESCRIPTION
## Purpose
This PR fixes an issue where the AtomSpace-based deme storage produced degraded benchmark scores compared to the tuple-based implementation due to generational state leakage.

## Overview of Changes
- **deme/expand.metta**: Updated the recursive `runMoses` call to increment `$nExpansion` by 1 at each generation. 

## Context & "Why"
Previously, `$nExpansion` remained stuck at 0 across generations. Because `$nDeme=1`, duplicate IDs (`mkDemeId 1`) were generated every cycle. The underlying Python layer reused the exact same AtomSpace handle, causing subsequent generations to add fresh representations and empty instance sets into an uncleared space. 

Due to MeTTa's non-deterministic pattern matching, `match` statements returned a superposition of old and new data, causing the optimizer to accidentally fork, resurrect older candidates, and break generational boundaries. Forcing unique IDs via `$nExpansion` completely isolates generation states and perfectly matches the tuple repository's benchmark scores.